### PR TITLE
fix gh actions & commit msg limits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Publish to NPM
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
 
 jobs:
   publish:
@@ -28,7 +30,17 @@ jobs:
         id: package-version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
         
+      - name: Check if version tag exists
+        id: check-tag
+        run: |
+          if git tag -l "v${{ steps.package-version.outputs.version }}" | grep -q "v${{ steps.package-version.outputs.version }}"; then
+            echo "tag-exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "tag-exists=false" >> $GITHUB_OUTPUT
+          fi
+        
       - name: Publish to NPM
+        if: steps.check-tag.outputs.tag-exists == 'true'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,6 @@ npm version patch|minor|major --no-git-tag-version
 git add .
 git commit -m "bump version to X.X.X
 
-Release Notes:
 - Feature 1: Description
 - Feature 2: Description
 - Bug Fix: Description
@@ -78,6 +77,8 @@ git push origin release/vX.X.X
 - **NEVER add Claude as Co-Authored-By** in commit messages
 - **Keep commit messages clean** and professional
 - **Focus on the actual changes** made, not the AI assistance used
+- **Subject line max 50 characters** - GitHub standard for commit titles
+- **Body text max 72 characters** - Wrap commit body at 72 characters
 
 ## 🛠️ **Technology Stack**
 


### PR DESCRIPTION
- fix GitHub Actions to only publish on releases
- add commit message character limits (50/72)
- shorten commit template example