### PR TITLE
fix task status auto-progression and add robust configuration validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,38 @@ git push origin release/vX.X.X
 # 9. After PR merge, GitHub Actions will automatically publish to npm
 ```
 
+### **Semantic Versioning Guidelines:**
+
+**PATCH (X.X.1)** - Bug fixes and small improvements:
+```bash
+npm version patch --no-git-tag-version
+```
+- Bug fixes that don't change API
+- Documentation updates
+- Internal refactoring without behavior change
+- Performance improvements
+- Security patches
+
+**MINOR (X.1.0)** - New features that are backward compatible:
+```bash
+npm version minor --no-git-tag-version
+```
+- New CLI commands or options
+- New API methods or properties
+- New configuration options (with defaults)
+- Enhanced functionality that doesn't break existing usage
+- New workflow files or templates
+
+**MAJOR (1.0.0)** - Breaking changes:
+```bash
+npm version major --no-git-tag-version
+```
+- Changes to existing API method signatures
+- Removal of CLI commands or options
+- Changes to configuration file structure requiring user updates
+- Changes to default behavior that could break existing workflows
+- Node.js version requirement changes
+
 ### **Important Notes:**
 
 **For Task Execution:**
@@ -230,6 +262,8 @@ try {
 - **Error on missing config** - Throw clear errors if required config is missing
 - **Case-insensitive matching** - Match property names ignoring case
 - **Type validation** - Ensure properties match expected types
+- **Graceful degradation** - Handle missing optional config (like testStatus) with warnings
+- **Status validation** - Validate that configured statuses exist in Notion database
 
 ## 🔄 **Workflow Integration**
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Notion AI Tasks enables AI assistants (Claude Code, GitHub Copilot, etc.) to sea
 1. **AI reads task specifications** from Notion database
 2. **AI updates task status** to "In Progress" and follows implementation plan
 3. **AI marks todos as complete** during development
-4. **System automatically moves task to "Test"** when all todos are done
-5. **Human manually marks as "Done"** after validation
+4. **System automatically moves task to "Test"** when all todos are done (prevents accidental auto-completion)
+5. **Human manually validates and marks as "Done"** after testing
 
 ## 🎬 Demo
 
@@ -68,6 +68,26 @@ npm install -g notion-ai-tasks
      "completionStatus": "Done"
    }
    ```
+
+### Configuration Fields
+
+**Required Fields:**
+- `notionToken` - Your Notion integration token
+- `databaseId` - Your Notion database ID
+- `defaultStatus` - Initial status for new tasks
+- `inProgressStatus` - Status when work begins
+
+**Optional Fields:**
+- `testStatus` - Status for completed tasks awaiting manual validation (recommended)
+- `completionStatus` - Final status for validated tasks
+- `statuses`, `priorities`, `types` - Used for validation but not required
+
+**Status Auto-Progression:**
+- `defaultStatus` → `inProgressStatus` (when first todo is checked)
+- `inProgressStatus` → `testStatus` (when all todos completed) 
+- `testStatus` → `completionStatus` (manual only)
+
+⚠️ **Note:** If `testStatus` is not configured, tasks will remain in `inProgressStatus` when completed, requiring manual status updates to prevent accidental auto-completion.
 
 ## 📋 Usage
 

--- a/notion-tasks.config.json.backup
+++ b/notion-tasks.config.json.backup
@@ -1,0 +1,13 @@
+   {
+     "notionToken": "ntn_c36654597194ciUXCH9RcZPlHTo7joVxZuH7zB7ttOW91G",
+     "databaseId": "2280da7a7a07809eb814ce67ea62721b",
+     "statuses": ["Not Started", "In Progress", "Test", "Done"],
+     "priorities": ["Low", "Medium", "High"],
+     "types": ["Bug", "Feature", "Task", "Documentation", "Refactoring"],
+     "defaultPriority": "Medium",
+     "defaultType": "Task",
+     "defaultStatus": "Not Started",
+     "inProgressStatus": "In Progress",
+     "testStatus": "Test",
+     "completionStatus": "Done"
+   }

--- a/src/core/NotionClient.js
+++ b/src/core/NotionClient.js
@@ -16,11 +16,33 @@ class NotionClient {
       
       console.log('🤖 AI Instructions: 🚀 Use \'npx notion-ai-tasks\' for all Notion operations. Import { readWorkflow } from \'notion-ai-tasks/workflow-loader.js\' then readWorkflow(\'AI_WORKFLOW_SELECTOR.md\') to choose the correct workflow, then follow it EXACTLY. NEVER use WebFetch for Notion URLs.');
       
+      this.validateConfig(config);
       return config;
     } catch (error) {
       console.error('Error: notion-tasks.config.json not found in current directory');
       console.error('Please create a notion-tasks.config.json file with your Notion credentials');
       process.exit(1);
+    }
+  }
+
+  validateConfig(config) {
+    const requiredFields = ['notionToken', 'databaseId', 'defaultStatus', 'inProgressStatus'];
+    const missingFields = requiredFields.filter(field => !config[field]);
+    
+    if (missingFields.length > 0) {
+      console.error(`Error: Missing required configuration fields: ${missingFields.join(', ')}`);
+      process.exit(1);
+    }
+    
+    // Warn about missing testStatus
+    if (!config.testStatus) {
+      console.warn('⚠️  Warning: testStatus not configured. Tasks will not auto-progress from "In Progress" to "Test" when completed.');
+      console.warn('   Add "testStatus": "Test" to your configuration for proper workflow progression.');
+    }
+    
+    // Warn about missing completionStatus
+    if (!config.completionStatus) {
+      console.warn('⚠️  Warning: completionStatus not configured. Manual completion status may not work properly.');
     }
   }
 

--- a/src/core/TaskManager.js
+++ b/src/core/TaskManager.js
@@ -222,7 +222,18 @@ export class TaskManager {
   }
 
   async updateTodoInContent(taskId, todoText, checked) {
-    return await this.contentManager.updateTodoInContent(taskId, todoText, checked);
+    const result = await this.contentManager.updateTodoInContent(taskId, todoText, checked);
+    
+    // Auto-update task status based on progress after todo change
+    try {
+      const statusResult = await this.updateTaskStatusBasedOnProgress(taskId);
+      result.statusUpdate = statusResult;
+    } catch (error) {
+      console.warn('Failed to auto-update task status:', error.message);
+      result.statusUpdate = { success: false, error: error.message };
+    }
+    
+    return result;
   }
 
   async getHierarchicalStructure(taskId) {
@@ -247,5 +258,111 @@ export class TaskManager {
 
   generateContextualMessage(currentStep, completedTasks) {
     return this.hierarchicalParser.generateContextualMessage(currentStep, completedTasks);
+  }
+
+  async getTaskProgress(taskId) {
+    try {
+      const content = await this.contentManager.getTaskContent(taskId);
+      const todos = content.filter(block => block.type === 'to_do');
+      
+      if (todos.length === 0) {
+        return { total: 0, completed: 0, percentage: 0 };
+      }
+      
+      const completed = todos.filter(todo => todo.to_do.checked).length;
+      const percentage = Math.round((completed / todos.length) * 100);
+      
+      return { total: todos.length, completed, percentage };
+    } catch (error) {
+      console.error('Error getting task progress:', error);
+      throw error;
+    }
+  }
+
+  async markTaskProgress(taskId, steps) {
+    try {
+      const results = [];
+      for (const step of steps) {
+        const result = await this.updateTodoInContent(taskId, step.text, step.checked);
+        results.push(result);
+      }
+      return { success: true, results };
+    } catch (error) {
+      console.error('Error marking task progress:', error);
+      throw error;
+    }
+  }
+
+  async updateTaskStatusBasedOnProgress(taskId) {
+    try {
+      const progress = await this.getTaskProgress(taskId);
+      const currentTask = await this.getTask(taskId);
+      
+      // Only auto-update if task has todos
+      if (progress.total === 0) {
+        return { success: true, statusChanged: false, reason: 'No todos found' };
+      }
+      
+      let newStatus = currentTask.status;
+      let statusChanged = false;
+      
+      // Case-insensitive status comparison
+      const currentStatusLower = currentTask.status.toLowerCase();
+      const defaultStatusLower = this.config.defaultStatus?.toLowerCase() || '';
+      const inProgressStatusLower = this.config.inProgressStatus?.toLowerCase() || '';
+      
+      // Auto-progression rules
+      if (currentStatusLower === defaultStatusLower && progress.percentage > 0) {
+        // Start progress when first todo is checked
+        if (this.config.inProgressStatus) {
+          newStatus = this.config.inProgressStatus;
+          statusChanged = true;
+        }
+      } else if (currentStatusLower === inProgressStatusLower && progress.percentage === 100) {
+        // Move to Test when all todos are completed - with fallback to completionStatus
+        if (this.config.testStatus) {
+          newStatus = this.config.testStatus;
+          statusChanged = true;
+        } else if (this.config.completionStatus) {
+          // Fallback: if no testStatus configured, skip auto-progression to Done
+          console.warn('Warning: testStatus not configured. Task remains in progress for manual review.');
+          return { 
+            success: true, 
+            statusChanged: false, 
+            reason: 'testStatus not configured - manual review required',
+            progress: progress
+          };
+        }
+      }
+      
+      if (statusChanged) {
+        try {
+          await this.updateTask(taskId, { status: newStatus });
+          return { 
+            success: true, 
+            statusChanged: true, 
+            oldStatus: currentTask.status,
+            newStatus: newStatus,
+            progress: progress
+          };
+        } catch (error) {
+          if (error.message.includes('invalid select')) {
+            console.error(`Error: Status "${newStatus}" does not exist in Notion database. Please add it to the Status property options.`);
+            return { 
+              success: false, 
+              statusChanged: false, 
+              error: `Status "${newStatus}" not found in Notion database`,
+              progress: progress
+            };
+          }
+          throw error;
+        }
+      }
+      
+      return { success: true, statusChanged: false, progress: progress };
+    } catch (error) {
+      console.error('Error updating task status based on progress:', error);
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
- Implement missing TaskManager methods: getTaskProgress, markTaskProgress, updateTaskStatusBasedOnProgress
- Fix status progression: tasks now auto-progress to Test instead of Done when todos completed
- Add case-insensitive status comparison to handle Notion vs config differences
- Add graceful degradation for missing testStatus configuration
- Add configuration validation with helpful warnings for missing optional fields
- Add error handling for invalid status names in Notion database
- Update README.md with configuration documentation and status progression explanation
- Add semantic versioning guidelines to CLAUDE.md for release management